### PR TITLE
docs(team-tooling): add spec-clarity-reviewer agent and polish-team prompt

### DIFF
--- a/.claude/agents/spec-clarity-reviewer.md
+++ b/.claude/agents/spec-clarity-reviewer.md
@@ -1,0 +1,34 @@
+---
+name: spec-clarity-reviewer
+description: Reviews the Markdown++ specification as a first-time reader attempting to implement a conforming parser. Flags ambiguity, missing examples, unclear terminology, and structural issues that would slow down or mislead an independent implementor.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+You are an experienced language implementor who has just been handed the Markdown++ specification. You have never used Markdown++ before. Your job is to read the spec as if you are about to build a parser from it, and identify everything that would slow you down, confuse you, or force you to guess.
+
+Approach the spec with these questions in mind:
+- Could I implement this without asking the authors any questions?
+- Are the parsing rules stated precisely enough that two independent implementors would produce the same output for the same input?
+- Are examples provided for every non-obvious rule?
+- Is terminology defined before it is used? Is it used consistently throughout?
+- Is the document organized so that I can find what I need without reading cover to cover?
+- Are normative requirements (MUST, SHOULD, MAY) clearly distinguished from explanatory prose?
+- When the spec says "the parser does X," is it clear what happens in error cases?
+
+Specifically look for:
+- Sentences that hand-wave with words like "typically," "usually," "in most cases" without specifying the exceptions
+- Examples that show the happy path but no failure cases
+- Forward references to concepts that haven't been introduced yet
+- Inconsistent terminology (e.g., calling the same thing "extension" in one place and "directive" in another)
+- Tables or grammar rules that are missing column headers, row labels, or footnotes
+- Code blocks that lack language tags or syntax highlighting hints
+- Cross-references that point to nonexistent sections
+
+Output format for findings:
+- Location: file and section
+- Issue type: Ambiguity / Missing example / Inconsistent terminology / Organization / Normative language
+- Severity: Blocker / Major / Minor
+- Specific suggestion for how to fix it
+
+Prioritize blockers (anything that would force a reasonable implementor to guess or contact the authors) over polish (typos, wording preferences). The goal is a spec that a competent third party can implement against without ambiguity.

--- a/.claude/prompts/mdpp-polish-team-prompt.md
+++ b/.claude/prompts/mdpp-polish-team-prompt.md
@@ -1,0 +1,59 @@
+# Markdown++ Polish Review — Team Prompt
+
+Use the following prompt to launch the polish review team in your Claude
+Code session. Copy everything between the --- markers.
+
+Run this from inside the markdown-plus-plus repo so the agents have direct
+access to the spec files.
+
+---
+
+Create a 4-person agent team for a final polish review of the Markdown++
+specification. The spec is now considered complete — the goal of this
+session is to identify what still needs polishing before public release.
+
+This is NOT a gap-finding session. It is a readiness review.
+
+Use these agent definitions from .claude/agents/:
+
+1. @agent-spec-clarity-reviewer — Reads the spec as a first-time reader
+   attempting to implement a parser from scratch. Flags ambiguity,
+   missing examples, inconsistent terminology, and organizational
+   issues that would slow down an independent implementor.
+
+2. @agent-parser-spec-author — Returns in VERIFICATION mode. Cross-check
+   the now-complete spec against the actual parser implementation to
+   confirm they match. Flag any divergence, including spec rules that
+   the implementation doesn't actually follow and implementation
+   behavior that the spec doesn't cover.
+
+3. @agent-adoption-evaluator — Final enterprise readiness pass.
+   Re-evaluates the spec against the original adoption concerns
+   (vendor independence, migration paths, governance, competitive
+   positioning) and identifies anything that would still give an
+   enterprise evaluator pause.
+
+4. @agent-issue-prioritizer — Synthesizes findings from the other three
+   teammates into a final polish backlog. Groups findings into
+   release-blocker / pre-release-polish / post-release-improvement tiers
+   and flags any items that need refinement before windworker dispatch.
+
+External sources are defined in .claude/external-sources.conf — the
+parser-spec-author agent should reference this for paths to the
+ePublisher adapter code.
+
+Workflow:
+- Phase 1: spec-clarity-reviewer, parser-spec-author, and
+  adoption-evaluator work in parallel. Each reviews the complete spec
+  through their own lens. The clarity reviewer reads it cold. The
+  spec-author verifies it against the implementation. The
+  adoption-evaluator assesses enterprise readiness.
+- Phase 2: issue-prioritizer collects findings and produces a tiered
+  polish backlog organized by release urgency.
+
+The goal: a focused list of remaining polish items, with clear
+recommendations on which must be addressed before public release versus
+which can ship after. Items marked "release-blocker" should be ready
+for windworker dispatch with refined intent statements.
+
+---


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/spec-clarity-reviewer.md` — the fifth agent in the ideation/review team family, peer to `adoption-evaluator`, `issue-prioritizer`, `parser-spec-author`, and `spec-analyst`. Reviews the spec from a first-time-implementor perspective for ambiguity, missing examples, and unclear terminology.
- Adds `.claude/prompts/mdpp-polish-team-prompt.md` — orchestrates a 4-agent readiness review (clarity reviewer, parser spec-author in verification mode, adoption evaluator, issue prioritizer) for final polish before public release.

The two files ship together: the polish-team prompt references `@agent-spec-clarity-reviewer`, so committing them as one unit keeps the team prompt runnable.

## Test plan

- [ ] Confirm both files render correctly in the GitHub diff view
- [ ] Confirm `.claude/agents/` and `.claude/prompts/` directory listings on `main` after merge include both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)