### PR TITLE
Closes finding 4 on PR #109: bound add-aliases ALIAS_PATTERN to comment terminator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "markdown-plus-plus",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "icon": "brand/logo.svg",
   "owner": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Tooling** -- Changes to the Claude Code plugin, validation scripts, and other tools.
 - **Project** -- Repository structure, documentation, and governance changes.
 
+## [1.7.2] - 2026-05-23
+
+### Tooling
+
+- `add-aliases.py` `ALIAS_PATTERN` now stops capture at the comment terminator, so compact-form aliases like `<!--#intro-->` extract as `intro` rather than `intro--`. The body character class contained `-` without a terminating lookahead, causing `get_existing_aliases` to greedily consume the `-->` closing sequence for any alias without whitespace between the name and the closing `-->`. `validate-mdpp.py` was unaffected (its extraction regex already used a terminating lookahead), so MDPP002/MDPP008 detection has always been correct. The impact was on `add-aliases.py` deduplication: when running the script against a file already containing compact-form aliases, the script saw the existing alias under a different name (`intro--`) than the validator (`intro`) and could inject a duplicate. Added the first `test_add_aliases.py` unit-test file (stdlib `unittest`, no new dependencies) covering compact, spaced, hyphenated, digit-first, Unicode-letter, and combined-command alias extraction (PR review finding on [#108](https://github.com/quadralay/markdown-plus-plus/pull/109)).
+
 ## [1.7.1] - 2026-05-23
 
 ### Project

--- a/plugins/markdown-plus-plus/.claude-plugin/plugin.json
+++ b/plugins/markdown-plus-plus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-plus-plus",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/add-aliases.py
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/add-aliases.py
@@ -69,6 +69,7 @@ HEADING_PATTERN = re.compile(r'^(#{1,6})\s+(.+)$')
 ALIAS_PATTERN = re.compile(
     f'<!--\\s*#([{_NCNAME_START_CHAR}0-9]'
     f'[{_NCNAME_START_CHAR}0-9{_NCNAME_COMBINING}-]*)'
+    f'(?=\\s*(?:;|-->))'
 )
 EXISTING_ALIAS_LINE = re.compile(
     f'^<!--\\s*#[{_NCNAME_START_CHAR}0-9]'

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/test_add_aliases.py
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/test_add_aliases.py
@@ -1,0 +1,79 @@
+"""Tests for add-aliases.py.
+
+Run with: python -m unittest test_add_aliases
+(must be invoked from this scripts/ directory)
+"""
+
+import importlib.util
+import os
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "add_aliases", os.path.join(_HERE, "add-aliases.py")
+)
+add_aliases = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(add_aliases)
+
+
+class GetExistingAliasesTests(unittest.TestCase):
+    def test_compact_form_does_not_over_capture(self):
+        # Regression: ALIAS_PATTERN body class includes '-' without a
+        # terminating lookahead would greedily match '-->' as 'name--'.
+        self.assertEqual(
+            add_aliases.get_existing_aliases("<!--#intro-->"),
+            {"intro"},
+        )
+
+    def test_compact_form_hyphenated_name(self):
+        self.assertEqual(
+            add_aliases.get_existing_aliases("<!--#sh-ug-installation-->"),
+            {"sh-ug-installation"},
+        )
+
+    def test_compact_form_digit_first(self):
+        self.assertEqual(
+            add_aliases.get_existing_aliases("<!--#04499224-->"),
+            {"04499224"},
+        )
+
+    def test_spaced_form(self):
+        self.assertEqual(
+            add_aliases.get_existing_aliases("<!-- #intro -->"),
+            {"intro"},
+        )
+
+    def test_unicode_letter_alias_compact(self):
+        self.assertEqual(
+            add_aliases.get_existing_aliases("<!--#Café-->"),
+            {"Café"},
+        )
+
+    def test_combined_command_alias_is_not_extracted(self):
+        # ALIAS_PATTERN starts with '<!--\\s*#' and so only matches
+        # standalone alias comments where '#' immediately follows the
+        # opening '<!--'. Aliases inside combined-command comments
+        # (e.g., '<!--style:Foo ; #intro-->') are intentionally not
+        # extracted here -- pre-existing scope of this script.
+        self.assertEqual(
+            add_aliases.get_existing_aliases("<!--style:Foo ; #intro-->"),
+            set(),
+        )
+
+    def test_multiple_aliases_in_document(self):
+        content = (
+            "# Heading One\n"
+            "<!--#one-->\n"
+            "# Heading Two\n"
+            "<!-- #two -->\n"
+            "# Heading Three\n"
+            "<!--#three-with-hyphens-->\n"
+        )
+        self.assertEqual(
+            add_aliases.get_existing_aliases(content),
+            {"one", "two", "three-with-hyphens"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses [residual finding 4](https://github.com/quadralay/markdown-plus-plus/pull/109#issuecomment-4524143918) from the PR #109 review (engineer-auto Phase 4).

## Summary

- `add-aliases.py` `ALIAS_PATTERN` greedily consumed the `-->` closing sequence for any alias without whitespace between the name and `-->`. Compact form `<!--#intro-->` extracted as `intro--`.
- The validator (`validate-mdpp.py`) was unaffected — its extraction regex already uses `(?=\s*;|\s*-->)`. The asymmetry meant `add-aliases.py`'s deduplication saw existing aliases under different names than the validator, and could inject duplicates above headings whose existing alias was misread.
- Fix mirrors the validator's lookahead discipline.
- Added the first `test_add_aliases.py` (stdlib `unittest`, zero new dependencies) — covers compact, spaced, hyphenated, digit-first, Unicode-letter, and combined-command extraction. The combined-command test documents the pre-existing scope limitation that `ALIAS_PATTERN` only matches standalone alias comments.
- Patch version bump to 1.7.1.

## Why fix before #111

#111 will add fixtures with compact-form Unicode-letter and dotted-hierarchy aliases (`<!--#chapter.1.intro-->`, `<!--#api.v1.users-->`). The over-capture would extract `chapter.1.intro--`, muddying #111's MDPP008 normalization work. Fixing the bug separately keeps #111's diff focused on its scope (NCName `NameChar` extension) rather than entangling a regex-discipline fix.

## Test plan

- [x] `python -m unittest test_add_aliases -v` — 7 tests pass
- [x] `validate-mdpp.py` regression on `sample-basic.md` — clean
- [ ] Visual review of CHANGELOG entry

## Notes

- Pre-existing limitation: `ALIAS_PATTERN` doesn't extract aliases from combined-command comments (`<!--style:Foo ; #intro-->`). This is unchanged and is now documented by `test_combined_command_alias_is_not_extracted`. Out of scope for this PR.
- Other residual findings from the same review (P2 #3 "strict superset" doc claim, P3 #5 CommonMark equivalence wording, P3 #6 confusables advisory, P3 #7 NBSP whitespace edge case, P3 #8 PEG surrogate-pair note) are independent and can be addressed in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)