### PR TITLE
Closes findings 3 and 5 on PR #109: scope superset claim to MDPP002, soften CommonMark equivalence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "markdown-plus-plus",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "icon": "brand/logo.svg",
   "owner": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Tooling** -- Changes to the Claude Code plugin, validation scripts, and other tools.
 - **Project** -- Repository structure, documentation, and governance changes.
 
+## [1.7.3] - 2026-05-23
+
+### Tooling
+
+- Clarified two documentation surfaces that overstated the scope of the 1.7.0 alias-grammar change. `references/error-codes.md` § *Alias Name* and `references/syntax-reference.md` § *Naming Rules > Alias Name* both characterized the new grammar as a "strict superset of the prior ASCII-only pattern." The claim is true for MDPP002 *acceptance* but misleading for *whole-document validation*, because MDPP008 (duplicate alias) tightened in 1.7.0 from byte-exact comparison to NFC + casefold -- documents with previously-distinct aliases like `<!--#FOO-->` and `<!--#foo-->` now fail MDPP008 as canonical-equivalent duplicates. Reframed both surfaces to scope the superset claim to MDPP002 and added an explicit *Migration note (1.7.0)* in `references/error-codes.md` cross-referencing the three MDPP008 sub-state messages. Also corrected the `_alias_dedup_key` docstring in `scripts/validate-mdpp.py`, which claimed CommonMark 0.30 equivalence -- CommonMark 0.30 §4.7 mandates casefold only; the Markdown++ implementation is stricter because it adds NFC. No syntax, semantics, or validator behavior changed (residual findings 3 and 5 from PR [#109](https://github.com/quadralay/markdown-plus-plus/pull/109) review).
+
 ## [1.7.2] - 2026-05-23
 
 ### Tooling

--- a/plugins/markdown-plus-plus/.claude-plugin/plugin.json
+++ b/plugins/markdown-plus-plus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-plus-plus",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/error-codes.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/error-codes.md
@@ -56,7 +56,9 @@ Markdown++ defines three naming patterns. The pattern applied depends on the ent
 
 ### Alias Name
 
-Alias names use the XML 1.0 NCName `NameStartChar` letter class -- ASCII letters and letters from non-Latin scripts (Japanese, German with combining accents, Greek, Cyrillic, and others) -- plus digits, underscore, and hyphen. Aliases additionally permit a leading digit, since aliases often map to numeric identifiers (e.g., `<!--#04499224-->`). The alias grammar is a strict superset of the prior ASCII-only pattern -- every alias valid under the previous grammar remains valid.
+Alias names use the XML 1.0 NCName `NameStartChar` letter class -- ASCII letters and letters from non-Latin scripts (Japanese, German with combining accents, Greek, Cyrillic, and others) -- plus digits, underscore, and hyphen. Aliases additionally permit a leading digit, since aliases often map to numeric identifiers (e.g., `<!--#04499224-->`). The alias **acceptance grammar** (MDPP002) is a strict superset of the prior ASCII-only pattern -- every alias valid under the previous grammar still passes MDPP002.
+
+**Migration note (1.7.0).** Whole-document validation is *not* a strict superset. MDPP008 (duplicate alias) tightened from byte-exact comparison to NFC + casefold, so documents that previously had distinct aliases like `<!--#FOO-->` and `<!--#foo-->`, or precomposed vs. decomposed accented forms, now fail MDPP008 as canonical-equivalent duplicates. See [MDPP008 -- Duplicate Alias](#mdpp008----duplicate-alias) for the three sub-state messages (byte-exact, case-fold, NFC-equivalent) and the diagnostic each one carries.
 
 **Grammar:** See [`spec/formal-grammar.md`](../../../../../spec/formal-grammar.md) `alias_name_start_char` and `alias_name_char` productions for the complete character enumeration. The validator (`scripts/validate-mdpp.py`) builds the equivalent Python character class from explicit `\u`/`\U` escapes at module-level constant `_NCNAME_START_CHAR`.
 

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/syntax-reference.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/syntax-reference.md
@@ -192,7 +192,7 @@ Alias names use the XML 1.0 NCName `NameStartChar` letter class -- which include
 - Minimum length is 1 character
 - No whitespace, no punctuation other than `-` and `_`, no leading `.`
 
-See [`spec/formal-grammar.md`](../../../../../spec/formal-grammar.md) `alias_name_start_char` and `alias_name_char` productions for the complete character enumeration. The alias namespace is a strict superset of the prior ASCII-only grammar -- every alias valid under the previous grammar remains valid.
+See [`spec/formal-grammar.md`](../../../../../spec/formal-grammar.md) `alias_name_start_char` and `alias_name_char` productions for the complete character enumeration. The alias **acceptance grammar** (MDPP002) is a strict superset of the prior ASCII-only grammar -- every alias valid under the previous grammar still passes MDPP002. Whole-document validation is *not* a strict superset: MDPP008 (duplicate alias) tightened in 1.7.0 from byte-exact to NFC + casefold, so canonical-equivalent variants like `<!--#FOO-->` and `<!--#foo-->` now collide. See `references/error-codes.md` § MDPP008 for the migration detail.
 
 **Applies to:** Aliases
 

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/validate-mdpp.py
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/validate-mdpp.py
@@ -132,8 +132,11 @@ def _alias_dedup_key(name: str) -> str:
 
     Applies Unicode NFC + casefold so canonical-equivalent variants
     (precomposed vs. decomposed accents; upper vs. lower case) compare
-    equal. Matches the equivalence relation used by CommonMark 0.30
-    link-reference-definition slug matching.
+    equal. Stricter than CommonMark 0.30 link-reference-definition
+    slug matching, which mandates casefold only (no NFC). The NFC step
+    is added so decomposed-accent aliases collide with their
+    precomposed counterparts -- safer for cross-system alias stability
+    than CommonMark's looser equivalence.
     """
     return unicodedata.normalize('NFC', name).casefold()
 


### PR DESCRIPTION
Addresses [residual findings 3 and 5](https://github.com/quadralay/markdown-plus-plus/pull/109#issuecomment-4524143918) from the PR #109 review (engineer-auto Phase 4).

## Summary

**Finding 3 (P2)** — Two documentation surfaces claimed the new alias grammar is a \"strict superset of the prior ASCII-only pattern.\" True for MDPP002 acceptance, misleading for whole-document validation: MDPP008 (duplicate alias) tightened in 1.7.0 from byte-exact comparison to NFC + casefold, so documents with previously-distinct aliases like \`<!--#FOO-->\` and \`<!--#foo-->\` now fail MDPP008 as canonical-equivalent duplicates.

- \`references/error-codes.md\` § *Alias Name* — scope the superset claim to MDPP002 acceptance, add a *Migration note (1.7.0)* with cross-reference to MDPP008's three sub-states.
- \`references/syntax-reference.md\` § *Naming Rules > Alias Name* — same scoping fix, shorter prose with pointer to error-codes.md for the migration detail.

**Finding 5 (P3)** — \`_alias_dedup_key\` docstring claimed CommonMark 0.30 link-reference equivalence. CommonMark 0.30 §4.7 mandates casefold only; the Markdown++ implementation is stricter because it adds NFC.

- \`scripts/validate-mdpp.py\` — reworded docstring to explicitly call out the NFC addition as stricter than CommonMark, and explained the rationale (decomposed-accent collision is safer for cross-system alias stability).

No syntax, semantics, or validator behavior changed.

## Sequencing

- **Bumped to 1.7.2**, assuming PR #113 (residual finding 4) lands first as 1.7.1. If this PR lands first, rebase to 1.7.1 and renumber.
- Both PRs should land before #111 is dispatched, so #111's new surfaces don't restate the misleading wording.

## Skipped findings

- **#6 (NCName supplementary-plane admits emoji/tag chars)** — intentionally not narrowing the grammar; the right remediation is a confusables advisory diagnostic (separate work).
- **#8 (PEG surrogate-pair note)** — spec polish, not blocking.
- **#7 (NBSP whitespace extraction)** — getting its own issue + dispatch.

## Test plan

- [x] Anchor link \`#mdpp008----duplicate-alias\` resolves to the section heading in \`error-codes.md\` (verified via GitHub slug algorithm: \`## MDPP008 -- Duplicate Alias\` → \`mdpp008----duplicate-alias\`)
- [x] No code paths touched — validator behavior identical
- [ ] Visual review of CHANGELOG migration framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)