### PR TITLE
Closes #126: Define rows-only condition granularity in tables; add MDPP019

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "markdown-plus-plus",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "icon": "brand/logo.svg",
   "owner": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Tooling** -- Changes to the Claude Code plugin, validation scripts, and other tools.
 - **Project** -- Repository structure, documentation, and governance changes.
 
+## [1.11.0] - 2026-07-05
+
+### Spec
+
+- Defined condition granularity within tables: **conditional rows are the supported granularity**. A condition block MAY wrap complete physical rows (standard table), complete logical rows including the trailing whitespace-only separator row (multiline table), or an entire table. A **conditional cell** (a span containing an unescaped `|` delimiter) MUST NOT be authored -- hiding it removes cell boundaries and corrupts the row's column count. An **in-cell condition span** (opening and closing within one cell on one line) SHOULD NOT be authored -- behavior is mechanically determined by Phase 1 raw-text evaluation, but the span resists line wrapping and corrupts the table if split across lines; prefer conditional row variants for structure and variables for value substitution. Because Phase 1 is table-blind, these are authoring requirements surfaced by validation, not processor behavior. `spec/multiline-cell-extensions.md` gains "Inline Conditions Within a Cell" and "Conditional Cells" subsections plus an explicit standard-table statement; `spec/specification.md` § 11.4 reworked to "Conditions and Tables" (was the looser "Condition blocks MAY appear within multiline table cells"), § 14.4 mirror paragraph tightened to match, MDPP019 added to the § 11.6 diagnostics table. New `GLOSSARY.md` terms: conditional row, in-cell condition span, conditional cell ([#126](https://github.com/quadralay/markdown-plus-plus/issues/126)).
+
+### Tooling
+
+- Added MDPP019 (warning) to `validate-mdpp.py`: a condition open/close tag embedded within a table row line -- an in-cell condition span or a conditional cell -- as opposed to full-line condition tags between rows, which remain the supported pattern. Detection skips fenced code blocks and backtick-quoted inline code (a quoted tag is verbatim text, not a live directive -- which also keeps the spec's own documentation tables clean). Added fixture `tests/sample-condition-in-table-cells.md` (three positive cases: multiline in-cell span, standard-table in-cell span, conditional cell; five negative cases: complete-logical-row wrap, complete-physical-row wrap, whole-table wrap, prose span, fenced example). Full MDPP019 entry in `references/error-codes.md`; `SKILL.md` gains Common Mistakes entry #5, an MDPP019 line in "Common errors detected," and a tightened extensions-in-cells summary; `references/best-practices.md` gains the do/don't note ([#126](https://github.com/quadralay/markdown-plus-plus/issues/126)).
+
 ## [1.10.0] - 2026-07-03
 
 ### Tooling

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -63,3 +63,21 @@ Full treatment: [Section 15 Content Islands](spec/specification.md#15-content-is
 Block-level content -- lists, blockquotes, styled elements, and other multi-line constructs -- inside a multiline table cell. Standard GFM tables limit each cell to a single line; the `<!-- multiline -->` directive enables continuation rows so that cells can hold block content. Multiline table cells are parsed as full Markdown documents with a separate parsing context per cell. Which extensions are valid inside a cell follows from the processing model's phase ordering: Phase 1 extensions (variables, conditions) operate on raw pipe-delimited text before the table is recognized; Phase 2 extensions (styles, aliases, markers, combined commands) operate during per-cell parsing.
 
 Full treatment: [Extensions in Multiline Table Cells](spec/multiline-cell-extensions.md).
+
+### conditional row
+
+The supported granularity for conditions in tables. A **conditional row** is a complete table row wrapped by a condition block: in a standard table, a condition block MAY wrap complete physical rows; in a multiline table, it MAY wrap complete logical rows -- the first row, all of its continuation rows, and its trailing whitespace-only separator row. A condition block MAY also wrap an entire table. Conditional rows evaluate identically to conditions anywhere else, because Phase 1 condition evaluation is table-blind (it operates on raw text before the table is recognized). Contrast with the in-cell condition span and conditional cell, which are authoring anti-patterns surfaced by validation (MDPP019).
+
+Full treatment: [Conditions in Multiline Table Cells](spec/multiline-cell-extensions.md).
+
+### in-cell condition span
+
+A condition span that opens and closes within a single table cell on one physical line. Authors **SHOULD NOT** author an in-cell condition span. Its behavior is mechanically determined by Phase 1 raw-text evaluation -- Visible strips the tags, Hidden removes the span (the cell may become empty), Unset passes tags and content through as literal cell text -- but the pattern resists line wrapping (the span is an unbreakable atomic unit for any wrapping tool) and a span split across physical lines corrupts the table when Hidden (removal consumes the intervening newline and pipe delimiters). Prefer conditional row variants for structural differences and variables for value substitution. The validator flags it as MDPP019 (warning).
+
+Full treatment: [Conditions in Multiline Table Cells](spec/multiline-cell-extensions.md).
+
+### conditional cell
+
+A condition span that contains an unescaped `|` cell delimiter. A conditional cell **MUST NOT** be authored: hiding such a span removes cell boundaries and changes the row's column count, so the resulting table structure is corrupt. Because Phase 1 condition evaluation is table-blind, a processor cannot reject the pattern -- it is an authoring requirement surfaced by validation (MDPP019, warning), not processor behavior. Use conditional rows for structural differences and variables for value substitution instead.
+
+Full treatment: [Conditions in Multiline Table Cells](spec/multiline-cell-extensions.md).

--- a/plugins/markdown-plus-plus/.claude-plugin/plugin.json
+++ b/plugins/markdown-plus-plus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-plus-plus",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/SKILL.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/SKILL.md
@@ -247,7 +247,7 @@ Enable block content (lists, blockquotes, styled elements) inside table cells.
 
 Every pipe-bearing row continues the current logical row. A row whose cells are all whitespace starts a new logical row — that's the only way to signal one. A no-pipe blank line ends the table. Cells on a continuation line appear empty when their column has no more content to flow there. Combine with style: `<!-- style:DataTable ; multiline -->`. See `references/syntax-reference.md` for multiline table rules.
 
-**Extensions in cells:** Variables, block/inline styles, markers, conditions (wrapping complete rows only — not partial rows), and combined commands work inside multiline table cells. Includes and nested multiline tables are not supported in cells. See `spec/multiline-cell-extensions.md`.
+**Extensions in cells:** Variables, block/inline styles, markers, conditions (conditional rows only — wrap complete rows or the whole table; don't author in-cell condition spans, and never a conditional cell that hides a `|` delimiter; MDPP019), and combined commands work inside multiline table cells. Includes and nested multiline tables are not supported in cells. See `spec/multiline-cell-extensions.md`.
 
 ### Combined Commands
 
@@ -319,6 +319,7 @@ python scripts/validate-mdpp.py document.md
 - Orphaned comment tags (tag not attached to element)
 - Duplicate link reference slugs across included files (MDPP014)
 - Multiline tables with no separator rows that silently merge data rows (MDPP018)
+- Condition open/close tags inside a table row line — in-cell spans or conditional cells (MDPP019)
 
 ## Alias Generation
 
@@ -425,6 +426,35 @@ See the [Attachment Rule specification](../../../../spec/attachment-rule.md) for
 ```
 
 See [MDPP018 -- Multiline Table Row Merge](references/error-codes.md#mdpp018----multiline-table-row-merge) for the detection logic.
+
+### 5. Conditions in Tables Below Row Granularity
+
+**Conditional rows are the supported granularity for conditions in tables.** A condition block MAY wrap complete physical rows (standard table) or complete logical rows including the trailing whitespace-only separator row (multiline table), or the whole table. Two finer patterns are authoring anti-patterns the validator flags as MDPP019 (warning): a **conditional cell** (a condition span containing an unescaped `|` delimiter) MUST NOT be authored -- hiding it removes cell boundaries and corrupts the row's column count; an **in-cell condition span** (opening and closing within one cell on one line) SHOULD NOT be authored -- it resists line wrapping and corrupts the table if a wrapping tool splits it across lines. Use conditional row variants for structural differences and variables for value substitution.
+
+**Wrong -- in-cell condition spans (MDPP019):**
+```markdown
+<!-- multiline -->
+| Platform | Shortcut                                          |
+|----------|---------------------------------------------------|
+| Save     | <!--condition:mac-->Cmd+S<!--/condition--><!--condition:win-->Ctrl+S<!--/condition--> |
+```
+
+**Right -- condition-wrapped whole rows (separator row inside the block):**
+```markdown
+<!-- multiline -->
+| Platform | Shortcut |
+|----------|----------|
+<!--condition:mac-->
+| Save     | Cmd+S    |
+|          |          |
+<!--/condition-->
+<!--condition:win-->
+| Save     | Ctrl+S   |
+|          |          |
+<!--/condition-->
+```
+
+See [MDPP019 -- Condition Inside a Table Cell](references/error-codes.md#mdpp019----condition-inside-a-table-cell) for the detection logic.
 
 </common_mistakes>
 

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/best-practices.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/best-practices.md
@@ -185,6 +185,39 @@ Click <!--condition:windows10-->Start<!--/condition--><!--condition:windows11-->
 <!--/condition-->
 ```
 
+**Conditions in tables: condition whole rows, not cells or cell fragments.** Conditional rows are the supported granularity for conditions in tables. A condition block may wrap complete physical rows (standard table), complete logical rows including the trailing whitespace-only separator row (multiline table), or the entire table. Two finer patterns are anti-patterns the validator flags as MDPP019 (warning):
+
+- **Don't author a conditional cell** -- a condition span that contains an unescaped `|` cell delimiter. Hiding it removes cell boundaries and changes the row's column count, so the table structure is corrupt. This one is a MUST NOT.
+- **Don't author an in-cell condition span** -- a span that opens and closes within a single cell on one physical line. Its behavior is well-defined (Visible strips the tags, Hidden removes the span, Unset passes it through as literal text), but the span is an unbreakable atomic unit that defeats line wrapping, and a wrapping tool that splits it across physical lines corrupts the table in the Hidden state. This one is a SHOULD NOT.
+- **Do condition whole rows** for structural differences (put the separator row *inside* the condition block so the logical row is complete), or **use variables** for value substitution such as platform names, key modifiers, and versions.
+
+Phase 1 condition evaluation is table-blind -- it operates on raw text before the table is recognized -- so these are authoring requirements surfaced by validation, not processor behavior.
+
+**Wrong -- in-cell condition spans (MDPP019):**
+```markdown
+<!-- multiline -->
+| Platform | Shortcut                                          |
+|----------|---------------------------------------------------|
+| Save     | <!--condition:mac-->Cmd+S<!--/condition--><!--condition:win-->Ctrl+S<!--/condition--> |
+```
+
+**Right -- condition-wrapped whole rows (separator row inside the block):**
+```markdown
+<!-- multiline -->
+| Platform | Shortcut |
+|----------|----------|
+<!--condition:mac-->
+| Save     | Cmd+S    |
+|          |          |
+<!--/condition-->
+<!--condition:win-->
+| Save     | Ctrl+S   |
+|          |          |
+<!--/condition-->
+```
+
+See [MDPP019](error-codes.md#mdpp019----condition-inside-a-table-cell).
+
 **Undefined condition names (Unset) — authoring guidance:**
 
 A condition name that is not included in the condition set at build time is **Unset** (see [GLOSSARY.md](../../../../../GLOSSARY.md#unset)). Unset condition blocks pass through the processor with their opening tags, content, and closing tags intact. This is intentional: it lets you author content for multiple output targets in a single source file, even if only some targets are active in a given build.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/error-codes.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/error-codes.md
@@ -30,6 +30,7 @@ Implementation-independent reference for all Markdown++ validation error codes. 
 | MDPP016 | Different major version in document | Warning | Document's `mdpp-version` major version differs from processor's supported major version |
 | MDPP017 | Invalid UTF-8 encoding | Error | File contains an invalid UTF-8 byte sequence |
 | MDPP018 | Multiline table row merge | Warning | `<!-- multiline -->` table has no separator rows; all data rows merge into one logical row |
+| MDPP019 | Condition inside a table cell | Warning | A condition open/close tag is embedded in a table row (in-cell span or conditional cell) instead of wrapping complete rows |
 
 ## General Rules
 
@@ -601,3 +602,65 @@ The first-cell test that distinguishes continuation rows from content-first rows
 ```
 
 **Suggested fix:** Use `<!-- multiline -->` only when a cell needs block content or wraps across lines. If the cells are single-line, drop the directive and use a plain table. If the rows genuinely need multiline cells, insert a whitespace-only separator row (e.g. `|  |  |`) between records so each renders as its own logical row.
+
+---
+
+## MDPP019 -- Condition Inside a Table Cell
+
+**Severity:** Warning
+
+**Description:** A condition open (`<!--condition:EXPR-->`) or close (`<!--/condition-->`) tag is embedded **within** a table row line, rather than sitting on its own line between rows. Two unsupported patterns produce this shape:
+
+- **In-cell condition span** -- a span that opens and closes within a single cell on one physical line (e.g. `| Support | Contact <!--condition:web-->email<!--/condition--> now. |`). A condition span that opens and closes within a single cell on one physical line SHOULD NOT be authored. Its behavior is mechanically determined by Phase 1 raw-text evaluation -- Visible strips the tags, Hidden removes the span (the cell may become empty), Unset passes tags and content through as literal cell text -- but the pattern resists line wrapping (the span is an unbreakable atomic unit for any wrapping tool) and a span split across physical lines corrupts the table when Hidden (removal consumes the intervening newline and pipe delimiters).
+- **Conditional cell** -- a span that contains an unescaped `|` cell delimiter (e.g. `| Pro | <!--condition:web-->email | phone<!--/condition--> | landline |`). A condition span that contains an unescaped `|` cell delimiter MUST NOT be authored. Hiding such a span removes cell boundaries and changes the row's column count; the resulting table structure is corrupt.
+
+Conditional rows are the supported granularity for conditions in tables. In a standard table, a condition block MAY wrap complete physical rows. In a multiline table, a condition block MAY wrap complete logical rows -- the first row, all of its continuation rows, and its trailing whitespace-only separator row. A condition block MAY also wrap an entire table. Those supported forms place the condition tag on its own line between rows, so the tag line carries no pipe delimiters and never triggers MDPP019.
+
+Phase 1 condition evaluation is table-blind (it operates on raw text), so these are authoring requirements surfaced by validation (MDPP019, warning), not processor behavior. Like MDPP018, the document still processes -- the diagnostic warns the author that the construct will not behave the way a table author expects.
+
+**Detection logic:** Pass over lines outside fenced code blocks. A line is flagged when it is both a pipe-table row (leading and trailing `|`, per the row shape used by MDPP018) and carries a **live** condition open or close tag. A condition tag written inside a backtick inline-code span is excluded: inline code is verbatim, so Phase 1 never treats a quoted `<!--condition:...-->` as a directive, and reference tables that document the syntax in a cell (grammar tables, error-code tables, comparison tables) must not be flagged. A tag preceded by an odd number of backticks on the line sits inside an open code span and is skipped.
+
+The line-shape heuristic is sufficient on its own -- a genuine table-detection pass would add no precision. Every supported pattern is excluded by construction: a full-line condition tag between rows carries no border pipes; an inline condition span in prose carries no border pipes; a fenced code example is skipped by the fence handling; and a documentation tag inside inline code is skipped by the backtick check. One diagnostic is emitted per offending row line, anchored to that line, regardless of how many tags it carries or whether the span crosses a cell delimiter.
+
+**Trigger examples:**
+
+```markdown
+<!-- WARNING: in-cell span in a multiline table -->
+<!-- multiline -->
+| Channel | How to reach us |
+| ------- | --------------- |
+| Support | Contact <!--condition:web-->email<!--/condition--> now. |
+| | |
+| Sales | Call the main office. |
+
+<!-- WARNING: in-cell span in a standard table -->
+| Channel | How to reach us |
+| ------- | --------------- |
+| Support | Contact <!--condition:web-->email<!--/condition--> now. |
+
+<!-- WARNING: conditional cell -- the span crosses a | delimiter -->
+| Plan | Web contact | Phone contact |
+| ---- | ----------- | ------------- |
+| Pro | <!--condition:web-->email | phone<!--/condition--> | landline |
+
+<!-- OK: condition wraps a complete logical row (tags on their own lines) -->
+<!-- multiline -->
+| Feature | Description |
+| ------- | ----------- |
+| Core | Available on all plans. |
+| | |
+<!--condition:enterprise-->
+| Enterprise | Premium features. |
+| | |
+<!--/condition-->
+
+<!-- OK: condition wraps a complete physical row of a standard table -->
+| Feature | Availability |
+| ------- | ------------ |
+| Core features | Included in every plan. |
+<!--condition:enterprise-->
+| Single sign-on | Enterprise plans only. |
+<!--/condition-->
+```
+
+**Suggested fix:** Wrap complete rows, not sub-row spans. In a standard table, wrap the complete physical row; in a multiline table, wrap the complete logical row (including its trailing whitespace-only separator row); or wrap the entire table. For value substitution inside one cell (platform names, key modifiers, versions), use a variable (`$name;`) instead of an in-cell condition span. For structural differences between variants, use conditional row variants. Never let a condition span contain an unescaped `|` -- that removes a cell boundary and corrupts the table.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/validate-mdpp.py
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/validate-mdpp.py
@@ -222,6 +222,16 @@ MULTILINE_DIRECTIVE_LINE_RE = re.compile(
 # Split a row on unescaped pipes (a `\|` is a literal pipe inside a cell).
 TABLE_CELL_SPLIT_RE = re.compile(r'(?<!\\)\|')
 
+# --- In-cell / conditional-cell condition detection (MDPP019) ----------------
+# A condition open (`<!--condition:EXPR-->`) or close (`<!--/condition-->`) tag,
+# anchored anywhere within a line. Used to detect a condition tag embedded in a
+# table row (an in-cell span or a conditional cell), as opposed to a full-line
+# condition tag between rows -- the supported granularity, which never matches
+# TABLE_ROW_RE because it carries no pipes.
+CONDITION_TAG_RE = re.compile(
+    r'<!--\s*(?:condition:[^>]+?|/condition)\s*-->'
+)
+
 
 def _is_mdpp_tag_line(line: str) -> bool:
     """True if line's only non-whitespace content is an MDPP comment tag."""
@@ -396,6 +406,93 @@ def _scan_multiline_row_merge(
 
         i += 1
 
+    return issues
+
+
+def _scan_condition_in_table_cells(
+    lines: list[str], filepath: str
+) -> list[ValidationIssue]:
+    """Detect condition tags embedded in a table row line (MDPP019).
+
+    Conditional rows are the supported granularity for conditions in tables: a
+    condition block MAY wrap complete physical rows (standard table) or complete
+    logical rows (multiline table), or an entire table. Those supported forms
+    put the `<!--condition:EXPR-->` / `<!--/condition-->` tag on its **own line**
+    between rows, so the tag line carries no pipe delimiters.
+
+    Two unsupported patterns instead place a condition tag **inside** a table
+    row line:
+
+    - **In-cell condition span** -- a span that opens and closes within a single
+      cell on one physical line (e.g. `Contact <!--condition:web-->email<!--/condition--> now.`).
+      Its behavior is mechanically determined by Phase 1 raw-text evaluation, but
+      the span is an unbreakable atomic unit for line-wrapping tools and a split
+      across physical lines corrupts the table when Hidden. Authors SHOULD NOT
+      author it.
+    - **Conditional cell** -- a condition span that contains an unescaped `|`
+      cell delimiter. Hiding it removes cell boundaries and changes the row's
+      column count; the resulting table structure is corrupt. Authors MUST NOT
+      author it.
+
+    Phase 1 condition evaluation is table-blind (it operates on raw text), so a
+    processor cannot reject these -- they are authoring requirements surfaced by
+    validation, not processor behavior. Detection therefore keys on line shape:
+    a line that is both a pipe-table row (leading and trailing `|`, per
+    TABLE_ROW_RE) **and** contains a condition open or close tag. A full-line
+    condition tag between rows never matches (no border pipes), and an inline
+    condition span in prose never matches (no border pipes), so the row-shape
+    heuristic alone excludes every supported pattern -- a genuine
+    table-detection pass would add no precision here. One diagnostic is emitted
+    per offending row line, anchored to that line, regardless of how many tags
+    it carries or whether the span crosses a cell delimiter.
+
+    A condition tag written inside a backtick inline-code span is documentation
+    *about* the syntax, not a live directive -- inline code is verbatim, so
+    Phase 1 never treats it as a condition span. Such tags are excluded: a tag
+    preceded by an odd number of backticks on the line sits inside an open code
+    span. This keeps MDPP019 off the many spec and reference tables whose cells
+    quote `<!--condition:...-->` as example code.
+    """
+    issues: list[ValidationIssue] = []
+    for line_num, line in _iter_outside_fences(lines):
+        if not TABLE_ROW_RE.match(line):
+            continue
+        if TABLE_DELIMITER_RE.match(line):
+            # A GFM delimiter row cannot carry a condition tag (its interior is
+            # whitespace, dashes, and colons only); skip it defensively.
+            continue
+        # Fire only on a live directive tag -- one not inside a backtick
+        # inline-code span. A tag with an odd number of backticks before it on
+        # the line is inside an open code span and is verbatim documentation.
+        has_live_tag = any(
+            line[:m.start()].count('`') % 2 == 0
+            for m in CONDITION_TAG_RE.finditer(line)
+        )
+        if not has_live_tag:
+            continue
+        issues.append(ValidationIssue(
+            type=Severity.WARNING.value,
+            code="MDPP019",
+            message=(
+                "Condition tag inside a table row; conditional rows are the "
+                "supported granularity for conditions in tables, not in-cell "
+                "spans or conditional cells"
+            ),
+            file=filepath,
+            line=line_num,
+            context=line.strip()[:60],
+            suggestion=(
+                "A condition span that contains an unescaped | delimiter "
+                "(conditional cell) MUST NOT be authored -- hiding it removes "
+                "cell boundaries and corrupts the table. A span that opens and "
+                "closes within one cell (in-cell span) SHOULD NOT be authored -- "
+                "it resists line wrapping and corrupts the table if split across "
+                "lines. Wrap complete rows instead (a condition block MAY wrap "
+                "complete physical rows, or a multiline table's complete logical "
+                "rows including the trailing whitespace-only separator row, or an "
+                "entire table), or use a variable for value substitution."
+            ),
+        ))
     return issues
 
 
@@ -673,6 +770,10 @@ def validate_file(filepath: str, verbose: bool = False) -> list[ValidationIssue]
 
     # MDPP018: Multiline tables with no separator rows (silent row merge).
     issues.extend(_scan_multiline_row_merge(lines, filepath))
+
+    # MDPP019: Condition tags embedded in a table row (in-cell span /
+    # conditional cell) rather than wrapping complete rows.
+    issues.extend(_scan_condition_in_table_cells(lines, filepath))
 
     # Check for unclosed conditions
     for opened_line, opened_expr in condition_stack:

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/sample-condition-in-table-cells.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/sample-condition-in-table-cells.md
@@ -1,0 +1,125 @@
+---
+mdpp-version: 1.0
+date: 2026-07-05
+status: active
+---
+
+# MDPP019 fixture -- condition tags inside table cells
+
+Fixtures for the MDPP019 validator warning (issue #126). Run the validator
+against this file; the expected outcome is documented in each section.
+
+```bash
+python scripts/validate-mdpp.py tests/sample-condition-in-table-cells.md
+```
+
+Expected: exactly **three** MDPP019 warnings -- one on each positive-case row
+below -- and exit code 0 (warning severity, not error).
+
+Conditional rows are the supported granularity for conditions in tables. A
+condition block MAY wrap complete physical rows (standard table) or complete
+logical rows (multiline table), or an entire table. MDPP019 fires only when a
+condition open or close tag is embedded **within** a table row line -- an
+in-cell span or a conditional cell -- never when a full-line condition tag sits
+between rows.
+
+## Wrong -- in-cell span in a multiline table (triggers MDPP019)
+
+The span opens and closes within a single cell on one physical line. Phase 1
+evaluates it, but the span is an unbreakable atomic unit for line wrapping and
+corrupts the table if a wrapping tool splits it across physical lines. Prefer a
+conditional row variant or a variable.
+
+<!-- multiline -->
+| Channel | How to reach us |
+| ------- | --------------- |
+| Support | Contact <!--condition:web-->email<!--/condition--> now. |
+| | |
+| Sales | Call the main office. |
+
+## Wrong -- in-cell span in a standard table (triggers MDPP019)
+
+The same in-cell span in a plain (non-multiline) table. The line is a pipe row
+carrying a condition tag, so it is flagged.
+
+| Channel | How to reach us |
+| ------- | --------------- |
+| Support | Contact <!--condition:web-->email<!--/condition--> now. |
+| Sales | Call the main office. |
+
+## Wrong -- conditional cell (span containing a | delimiter) (triggers MDPP019)
+
+The span stretches across an unescaped `|` cell delimiter. Hiding it removes a
+cell boundary and changes the row's column count -- the resulting table
+structure is corrupt. Authors MUST NOT author this.
+
+| Plan | Web contact | Phone contact |
+| ---- | ----------- | ------------- |
+| Pro | <!--condition:web-->email | phone<!--/condition--> | landline |
+| Free | forum | community |
+
+## Right -- condition wraps a complete logical row (no MDPP019)
+
+The condition block wraps a complete logical row of a multiline table -- the
+first row, its continuation row, and its trailing whitespace-only separator
+row. The tags sit on their own lines between rows, so no row line carries a
+condition tag.
+
+<!-- multiline -->
+| Feature | Description |
+| ------- | ----------- |
+| Core | Available on all plans. |
+| | - Basic analytics |
+| | |
+<!--condition:enterprise-->
+| Enterprise | Premium features: |
+| | - SSO integration |
+| | |
+<!--/condition-->
+| Community | Free tier features. |
+| | - Forum access |
+
+## Right -- condition wraps a complete physical row in a standard table (no MDPP019)
+
+The condition block wraps a complete physical row of a standard table. Phase 1
+sees whole lines, so wrapping the row works identically. The tags are full-line
+tags between rows -- not embedded in any row.
+
+| Feature | Availability |
+| ------- | ------------ |
+| Core features | Included in every plan. |
+<!--condition:enterprise-->
+| Single sign-on | Enterprise plans only. |
+<!--/condition-->
+| Community forum | Free tier and above. |
+
+## Right -- condition wraps an entire table (no MDPP019)
+
+The condition block wraps the whole table. Again the tags are full-line tags
+outside every row.
+
+<!--condition:print-->
+| Setting | Default |
+| ------- | ------- |
+| Verbose | false |
+| Telemetry | false |
+<!--/condition-->
+
+## Right -- inline span in prose (no MDPP019)
+
+An in-cell-style span in a normal paragraph is not a table row (no border
+pipes), so MDPP019 does not fire. This is the ordinary, supported use of inline
+condition spans outside tables.
+
+Contact <!--condition:web-->our support team<!--/condition--> for help.
+
+## Right -- in-cell span inside a fenced code example (no MDPP019)
+
+Everything inside a fenced code block is skipped, including a row that would
+otherwise trigger MDPP019 outside the fence.
+
+```markdown
+| Channel | How to reach us |
+| ------- | --------------- |
+| Support | Contact <!--condition:web-->email<!--/condition--> now. |
+```

--- a/spec/multiline-cell-extensions.md
+++ b/spec/multiline-cell-extensions.md
@@ -28,7 +28,7 @@ This phase ordering is the organizing principle for the rest of this document. W
 | Extension | Phase | Category | Notes |
 |-----------|:-----:|----------|-------|
 | Variables | 1 | Supported | Resolved before table is recognized |
-| Conditions | 1 | Supported | Operate on raw text; partial row wrapping produces undefined structure |
+| Conditions | 1 | Supported | Operate on raw text; complete rows only -- partial row wrapping produces undefined structure, in-cell spans discouraged (MDPP019) |
 | Includes | 1 | Not supported | MUST NOT appear inside cell content |
 | Block styles | 2 | Supported | Directive on continuation row attaches to following content |
 | Inline styles | 2 | Supported | Standard inline attachment rule applies |
@@ -70,6 +70,10 @@ Phase 2 then parses the resolved table normally.
 ### Conditions
 
 Conditions work in multiline table cells at the raw-text level. Condition blocks are evaluated per-file in Phase 1, Step 1 before table parsing. Conditions see the table rows as plain text lines and remove, keep, or pass them through (with condition tags preserved) based on the condition set.
+
+Conditional rows are the supported granularity for conditions in tables. In a standard table, a condition block MAY wrap complete physical rows. In a multiline table, a condition block MAY wrap complete logical rows -- the first row, all of its continuation rows, and its trailing whitespace-only separator row. A condition block MAY also wrap an entire table. The three subsections that follow specialize this rule for the multiline case; two further subsections define the in-cell patterns that SHOULD NOT and MUST NOT be authored.
+
+**Standard (non-multiline) tables.** This document is scoped to multiline table cells, but the standard-table case follows directly from the same Phase 1 mechanism. Because Phase 1 sees lines, a condition block that wraps complete physical rows of a standard GFM table evaluates identically to a condition block anywhere else in the document -- each wrapped row is a single line that the condition engine removes, keeps, or passes through as a unit. Standard tables have no continuation rows, so the "complete logical row" refinement below applies only to multiline tables.
 
 #### Wrapping Complete Rows
 
@@ -138,6 +142,51 @@ When `advanced` is Hidden, the two continuation rows are removed, leaving "Basic
 |             |                          |
 <!--/condition-->
 ```
+
+#### Inline Conditions Within a Cell
+
+A condition span that opens and closes within a single cell on one physical line SHOULD NOT be authored. Its behavior is mechanically determined by Phase 1 raw-text evaluation -- Visible strips the tags, Hidden removes the span (the cell may become empty), Unset passes tags and content through as literal cell text -- but the pattern resists line wrapping (the span is an unbreakable atomic unit for any wrapping tool) and a span split across physical lines corrupts the table when Hidden (removal consumes the intervening newline and pipe delimiters). Prefer conditional row variants for structural differences and variables for value substitution.
+
+Phase 1 condition evaluation is table-blind (it operates on raw text), so this is an authoring requirement surfaced by validation (**MDPP019**, warning), not processor behavior.
+
+**Example -- in-cell condition span (avoid):**
+
+```markdown
+<!-- multiline -->
+| Platform | Shortcut                                                   |
+|----------|------------------------------------------------------------|
+| Save     | Press <!--condition:mac-->Cmd+S<!--/condition--><!--condition:win-->Ctrl+S<!--/condition--> to save. |
+```
+
+**Example -- conditional row variants (preferred):**
+
+```markdown
+<!-- multiline -->
+| Platform | Shortcut                 |
+|----------|--------------------------|
+<!--condition:mac-->
+| Save     | Press Cmd+S to save.     |
+|          |                          |
+<!--/condition-->
+<!--condition:win-->
+| Save     | Press Ctrl+S to save.    |
+|          |                          |
+<!--/condition-->
+```
+
+Each variant wraps a complete logical row, so the condition engine removes or keeps whole rows and the table structure is never corrupted. Where only a value differs (a key modifier, a platform name, a version), a variable is the lighter tool: `Press $SaveKey; to save.`
+
+#### Conditional Cells
+
+A condition span that contains an unescaped `|` cell delimiter MUST NOT be authored. Hiding such a span removes cell boundaries and changes the row's column count; the resulting table structure is corrupt.
+
+As with in-cell spans, Phase 1 condition evaluation is table-blind, so this is an authoring requirement surfaced by validation (**MDPP019**, warning), not processor behavior. The following illustrates the corrupting pattern -- a condition span crossing a `|` delimiter:
+
+```markdown
+| Feature <!--condition:pro-->| Availability <!--/condition-->|
+```
+
+When `pro` is Hidden, the span (including the `|` before `Availability`) is removed, so the row loses a column delimiter and no longer matches the table's column count. Express the difference as complete conditional rows or columns present in every state instead.
 
 ### Includes
 

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -626,7 +626,7 @@ Conditions have the broadest interaction surface of any Markdown++ extension. Co
 
 **Conditions and Styles/Aliases/Markers:** All directive tags within a Hidden condition block are removed along with the content. Tags within Visible condition blocks follow normal attachment rules. Tags within Unset (pass-through) condition blocks are preserved as-is in the output.
 
-**Conditions and Multiline Tables:** Condition blocks MAY appear within multiline table cells. Defined condition content is evaluated during Phase 1 before table parsing in Phase 2. Unset condition blocks within table content pass through as-is, including the condition tags.
+**Conditions and Tables:** Conditional rows are the supported granularity for conditions in tables. In a standard table, a condition block MAY wrap complete physical rows; in a multiline table, a condition block MAY wrap complete logical rows (the first row, all continuation rows, and the trailing whitespace-only separator row); and a condition block MAY wrap an entire table. A condition span that contains an unescaped `|` cell delimiter MUST NOT be authored -- hiding it removes cell boundaries and corrupts the row's column count. A condition span that opens and closes within a single cell on one physical line SHOULD NOT be authored; its behavior is mechanically determined by Phase 1 raw-text evaluation, but the span resists line wrapping and corrupts the table when a wrap splits it across physical lines (prefer conditional row variants for structural differences and variables for value substitution). Because Phase 1 condition evaluation is table-blind (it operates on raw text), these are authoring requirements surfaced by validation (MDPP019, warning), not processor behavior. Defined condition content is evaluated during Phase 1 before table parsing in Phase 2, and Unset condition blocks within table content pass through as-is, including the condition tags. See [Extensions in Multiline Table Cells](multiline-cell-extensions.md#conditions) for the row-granularity rules, examples, and rationale.
 
 **Conditions and Content Islands:** Conditions MAY wrap or appear within content islands (styled blockquotes). If a condition wrapping or within a content island is Unset, the condition block passes through as-is.
 
@@ -641,6 +641,7 @@ Condition tags are **exempt** from the attachment rule. Conditions wrap content 
 | **MDPP001** | Unclosed condition block (missing `<!-- /condition -->`) or unmatched closing tag | Error |
 | **MDPP007** | Invalid condition expression syntax | Error |
 | **MDPP012** | Condition block spans across an include boundary (opens in one file, closes in another) | Error |
+| **MDPP019** | Condition span authored within a table row (in-cell span, or a span containing an unescaped `\|` cell delimiter) | Warning |
 
 ### 11.7 Examples
 
@@ -936,7 +937,7 @@ Standard Markdown alignment syntax (`:---`, `:---:`, `---:`) works in multiline 
 
 **Multiline Tables and Variables:** Variable tokens within multiline table cells are substituted during Phase 1, before table parsing in Phase 2.
 
-**Multiline Tables and Conditions:** Condition blocks MAY appear within multiline table cells. Defined condition content is evaluated during Phase 1 before table parsing in Phase 2. Unset condition blocks within table content pass through as-is, including the condition tags.
+**Multiline Tables and Conditions:** Conditional rows are the supported granularity -- a condition block MAY wrap complete logical rows (the first row, all continuation rows, and the trailing whitespace-only separator row) or an entire table. A condition span authored within a table row -- an in-cell span, or one containing an unescaped `|` cell delimiter -- SHOULD NOT or MUST NOT be authored respectively (MDPP019, warning). Defined condition content is evaluated during Phase 1 before table parsing in Phase 2. Unset condition blocks within table content pass through as-is, including the condition tags. See [section 11.4](#114-interaction-with-other-extensions) and [Extensions in Multiline Table Cells](multiline-cell-extensions.md#conditions).
 
 **Multiline Tables and Combined Commands:** In the recommended evaluation order, the `multiline` indicator is second (after style, before markers and alias). See [section 16](#16-combined-commands).
 


### PR DESCRIPTION
## Summary

Implements #126: **conditional rows are the supported granularity for conditions in tables.** A condition block MAY wrap complete physical rows (standard table), complete logical rows including the trailing whitespace-only separator row (multiline table), or an entire table. A **conditional cell** — a span containing an unescaped `|` delimiter — MUST NOT be authored (hiding it removes cell boundaries and corrupts the row's column count). An **in-cell condition span** SHOULD NOT be authored (it resists line wrapping and corrupts the table if split across lines; prefer conditional row variants for structure and variables for value substitution). Phase 1 condition evaluation is table-blind, so these are authoring requirements surfaced by validation, not processor behavior.

**Spec:**

- `spec/multiline-cell-extensions.md` — new "Inline Conditions Within a Cell" and "Conditional Cells" subsections with wrong/right examples, an explicit standard-table statement, and an updated Extension Summary note
- `spec/specification.md` — § 11.4 reworked from the loose "Condition blocks MAY appear within multiline table cells" to "Conditions and Tables" carrying the four canonical statements; § 14.4 mirror paragraph tightened to match; MDPP019 added to the § 11.6 diagnostics table

**Validator:**

- `validate-mdpp.py` — MDPP019 (warning): a condition open/close tag embedded within a table row line, as opposed to full-line tags between rows (the supported pattern, never flagged). Detection skips fenced code blocks and backtick-quoted inline code — a quoted tag is verbatim text, not a live directive, which also keeps the spec's own documentation tables clean
- `tests/sample-condition-in-table-cells.md` — 3 positive cases (multiline in-cell span, standard-table in-cell span, conditional cell) and 5 negative cases (complete-logical-row wrap, complete-physical-row wrap, whole-table wrap, prose span, fenced example)
- `references/error-codes.md` — full MDPP019 entry (quick-reference row, detection logic, trigger examples, fix guidance)

**Skill surfaces:**

- `SKILL.md` — Common Mistakes entry #5 (wrong: in-cell spans / right: condition-wrapped row variants), MDPP019 in "Common errors detected," tightened extensions-in-cells summary
- `references/best-practices.md` — do/don't note in the Conditions section
- `GLOSSARY.md` — new terms: **conditional row**, **in-cell condition span**, **conditional cell**

**Verification:** fixture reports exactly 3 MDPP019 warnings; corpus sweep shows MDPP019 fires only on the fixture and the six deliberate formatter-suite specimens (`condition-inline-span-*`, `i121-condition-span-atomic` — in-cell-span specimens by design), with zero hits across `spec/` and `examples/` and no new diagnostics of any other code; formatter suite ALL GREEN (15 pass / 19 known-fail / 0 unexpected-pass); `--idempotency` sweep clean. Cross-agent anchor consistency reconciled (`SKILL.md` and `best-practices.md` links now match the actual `error-codes.md` MDPP019 heading).

Noted for follow-up (out of scope): `spec/specification.md` § 18's global Diagnostic Registry is stale — it stops before MDPP015–MDPP018, so MDPP019 was added only to the § 11.6 per-section table pending a registry sync pass.

## Terminology

- [x] If this PR introduces or renames a Markdown++ term, `GLOSSARY.md` and at least one entry-point surface (README, spec, or skill) have been updated.

`GLOSSARY.md` adds *conditional row*, *in-cell condition span*, and *conditional cell*; the spec (§ 11.4, multiline-cell-extensions.md) and skill (SKILL.md, best-practices.md, error-codes.md) surfaces carry the same terms.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
