### PR TITLE
Closes #122: Treat full-line comments inside tables as pass-through members in format-tables.py

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "markdown-plus-plus",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "icon": "brand/logo.svg",
   "owner": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Tooling** -- Changes to the Claude Code plugin, validation scripts, and other tools.
 - **Project** -- Repository structure, documentation, and governance changes.
 
+## [1.12.0] - 2026-07-05
+
+### Tooling
+
+- `format-tables.py` no longer splits a table at a full-line HTML comment: comment lines inside a table run (condition open/close tags wrapping complete rows per the spec's Wrapping Complete Rows pattern, or any stray full-line comment including a mid-table `<!-- multiline -->` directive) are now **pass-through members** of the table block -- preserved byte-verbatim in place, with row accumulation continuing and column widths planned across the genuine data rows on both sides. Previously the scanner closed the block at the first non-pipe line, leaving every row below a condition tag unformatted and misaligned. One exception: a multiline-directive line immediately followed by a header row and separator row still opens a **new adjacent table** (lookahead), preserving existing adjacent-table behavior. This also resolves the design-doc known limitation "mid-table `<!-- multiline -->` directives silently split the table" as pass-through (the formatter is not a validator; mid-table, the directive is an orphaned comment). Documented as R17 in `references/table-formatting.md` with a generated worked example; design-doc limitation bullet updated. Flipped three `KNOWN_FAIL` suite fixtures to green (`i122-condition-midtable`, `i122-condition-midtable-standard`, `kl-midtable-multiline-directive` -- all matched their authored goldens byte-for-byte) and added the `adjacent-tables-directive-boundary` regression fixture pinning the lookahead. Suite: 19 pass / 16 known-fail / 0 unexpected-pass; idempotency sweep clean ([#122](https://github.com/quadralay/markdown-plus-plus/issues/122)).
+
 ## [1.11.0] - 2026-07-05
 
 ### Spec

--- a/docs/solutions/tooling-decisions/markdown-table-formatter-design-2026-05-09.md
+++ b/docs/solutions/tooling-decisions/markdown-table-formatter-design-2026-05-09.md
@@ -240,7 +240,14 @@ doesn't re-discover them:
 - **Mid-table `<!-- multiline -->` directives silently split the
   table.** The block scanner closes the table at the directive line;
   rows below render as raw prose. Either reject mid-table directives
-  with a parse error or treat them as in-table comments.
+  with a parse error or treat them as in-table comments. **Resolved in
+  #122** as pass-through comment members: any full-line HTML comment
+  mid-table (a stray directive, or the spec's condition open/close tags
+  wrapping complete rows) is preserved byte-verbatim in place with row
+  accumulation continuing past it and widths planned across both sides,
+  except that a `<!-- multiline -->` line immediately followed by a
+  header row and a separator row still closes the block to open a new
+  adjacent table.
 - **UTF-8 BOM defeats table detection.** Open with `utf-8-sig` to strip
   on read, then preserve-or-not on write per a config flag.
 - **Atomic write does not preserve original file mode** (becomes 0600

--- a/plugins/markdown-plus-plus/.claude-plugin/plugin.json
+++ b/plugins/markdown-plus-plus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-plus-plus",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/table-formatting.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/references/table-formatting.md
@@ -177,6 +177,63 @@ output across both runs. This is the property that makes the
 a "would reformat" diagnostic is reliable evidence the file is not yet
 formatted.
 
+### R17 -- Full-line HTML comments inside a table are pass-through members
+
+> The prose rules are numbered R1-R10; R11-R16 are internal
+> requirement numbers the script uses in its own comments (config
+> defaults, `--check` exit codes, non-table pass-through, and so on).
+> This rule takes the next free number, R17.
+
+A full-line HTML comment encountered while accumulating a table's rows --
+a line matching `^\s*<!--.*-->\s*$` -- no longer terminates the table.
+It becomes a **pass-through member** of the block: preserved
+byte-verbatim in place (no re-indent, no re-pad), with row accumulation
+continuing on the line after it. Column widths are planned across the
+genuine data rows on **both** sides of the comment, so one aligned grid
+spans the whole block; the comment line itself contributes nothing to
+the widths.
+
+This covers two authoring patterns:
+
+1. **Condition tags wrapping complete rows.** Full-line
+   `<!--condition:name-->` / `<!--/condition-->` tags between logical
+   rows of a `<!-- multiline -->` table -- the spec-sanctioned *Wrapping
+   Complete Rows* pattern (`spec/multiline-cell-extensions.md` §
+   Conditions). The rows inside the condition span align with the rows
+   outside it because widths are planned across the entire block.
+2. **A stray mid-table `<!-- multiline -->` (or any full-line)
+   comment.** The formatter is not a validator. Mid-table, an orphaned
+   directive comment is just a comment; it is passed through in place
+   rather than silently splitting the table (the resolution of the
+   former known limitation -- see *Known Limitations*).
+
+**New-table lookahead exception.** A mid-table comment that matches the
+multiline-directive form is *not* passed through when it is immediately
+followed by a header row and then a separator row (`<!-- multiline -->`
+then `| ... |` then `| --- |`). In that one case the directive is
+opening a fresh **adjacent** table, so the current block closes at the
+directive line and the directive becomes the leading directive of the
+next table. This preserves the existing adjacent-tables behavior: each
+table plans its widths from its own rows only.
+
+```markdown
+<!-- multiline -->
+| Feature    | Description             |
+| ---------- | ----------------------- |
+| Core       | Available on all plans. |
+|            | - Basic analytics       |
+<!--condition:enterprise-->
+| Enterprise | Premium features:       |
+|            | - SSO integration       |
+<!--/condition-->
+| Community  | Free tier features.     |
+```
+
+The `Feature` column is 10 wide because `Enterprise` -- a row *inside*
+the condition span -- is the widest cell in that column; the condition
+tags do not break width planning. A full worked example (including the
+lookahead exception) appears under *Worked Examples*.
+
 ## Configurable Parameters
 
 | Parameter             | Default | Description                                                                       |
@@ -329,6 +386,90 @@ that row.
 The blank middle row is preserved with whitespace-only cells padded to
 each column's full inner width.
 
+### Condition-wrapped rows and mid-table comments (R17)
+
+A `<!-- multiline -->` table with a condition-wrapped logical row (the
+spec's *Wrapping Complete Rows* pattern). The condition tags pass through
+verbatim in place, and widths are planned across the rows on both sides
+of them, so the whole table aligns as one grid.
+
+**Input:**
+
+```markdown
+<!-- multiline -->
+| Feature | Description |
+|-----|------------|
+| Core | Available on all plans. |
+|      | - Basic analytics |
+|   | - Email support |
+|  |  |
+<!--condition:enterprise-->
+| Enterprise | Premium features: |
+|     | - SSO integration |
+|         | - Dedicated support |
+|   |   |
+<!--/condition-->
+| Community | Free tier features. |
+|    | - Forum access |
+```
+
+**Output:**
+
+```markdown
+<!-- multiline -->
+| Feature    | Description             |
+| ---------- | ----------------------- |
+| Core       | Available on all plans. |
+|            | - Basic analytics       |
+|            | - Email support         |
+|            |                         |
+<!--condition:enterprise-->
+| Enterprise | Premium features:       |
+|            | - SSO integration       |
+|            | - Dedicated support     |
+|            |                         |
+<!--/condition-->
+| Community  | Free tier features.     |
+|            | - Forum access          |
+```
+
+The `Feature` column is padded to 10 characters because `Enterprise`,
+which lives inside the `<!--condition:enterprise-->` span, is the widest
+cell in that column -- width planning sees it despite the condition tags
+between it and the header.
+
+**New-table lookahead exception.** When a `<!-- multiline -->` comment is
+immediately followed by a header row and a separator row, it opens a new
+adjacent table instead of passing through:
+
+**Input:**
+
+```markdown
+| Term | Meaning |
+| ---- | ------- |
+| Alpha | First entry. |
+<!-- multiline -->
+| Feature | Description |
+| ------- | ----------- |
+| Beta | Second entry that runs a little longer. |
+```
+
+**Output:**
+
+```markdown
+| Term  | Meaning      |
+| ----- | ------------ |
+| Alpha | First entry. |
+<!-- multiline -->
+| Feature | Description                             |
+| ------- | --------------------------------------- |
+| Beta    | Second entry that runs a little longer. |
+```
+
+The `<!-- multiline -->` line closes the first (standard) table and
+becomes the directive of the second (multiline) table; each plans its
+widths from its own rows only.
+
 ## Known Limitations
 
 - **ASCII-dominant width measurement.** The formatter measures column
@@ -375,7 +516,14 @@ Run `python scripts/format-tables.py --help` for the full reference.
 - [`scripts/format-tables.py`](../scripts/format-tables.py) -- the
   conformance authority. The script's behavior is the rule set; this
   document trails the script when they disagree.
+- [`tests/format-tables/`](../tests/format-tables/) -- the golden-file
+  regression suite (run `python tests/run-tests.py` from the skill
+  root; add `--idempotency` for the R10 sweep). R17 is pinned by the
+  `i122-condition-midtable`, `i122-condition-midtable-standard`, and
+  `kl-midtable-multiline-directive` fixtures (pass-through members) and
+  by `adjacent-tables-directive-boundary` (the lookahead exception).
 - [`tests/format-tables-cases.md`](../tests/format-tables-cases.md) --
-  the manual-verification protocol covering AE1-AE7.
+  the human-readable AE1-AE7 protocol, superseded as the regression
+  gate by the golden-file suite above.
 - [`references/best-practices.md`](best-practices.md) -- the in-flow
   authoring guidance that points back to this document.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/format-tables.py
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/scripts/format-tables.py
@@ -88,6 +88,12 @@ MULTILINE_DIRECTIVE_LINE_RE = re.compile(
     r'^\s*<!--\s*[^>]*?\bmultiline\b[^>]*?-->\s*$'
 )
 
+# A line that is *only* a full-line HTML comment (e.g. a condition open/close
+# tag or a stray directive). Inside a table run these are pass-through member
+# lines: preserved byte-verbatim in place with row accumulation continuing
+# past them (issue #122).
+COMMENT_LINE_RE = re.compile(r'^\s*<!--.*-->\s*$')
+
 # Cell splitter: split on `|` but not on `\|` (R9).
 # Use a regex that matches `|` not preceded by an odd number of backslashes.
 # We approximate the simple case: split on `|` not preceded by `\`.
@@ -96,13 +102,25 @@ CELL_SPLIT_RE = re.compile(r'(?<!\\)\|')
 
 @dataclass
 class TableBlock:
-    """A pipe-table block scanned from the source."""
+    """A pipe-table block scanned from the source.
+
+    `members` is the ordered body of the block: each entry is either
+    ('row', cells) for a genuine data row (header included) or
+    ('comment', raw_line) for a full-line HTML comment that is passed
+    through byte-verbatim in place (issue #122). Width planning considers
+    only the 'row' members; renderers walk `members` in order so comment
+    lines land at their original position.
+    """
     start_line: int = 0          # 1-based line number of header row
     directive_line: Optional[str] = None  # original directive line, if any
     is_multiline: bool = False
-    rows: list[list[str]] = field(default_factory=list)
+    members: list[tuple] = field(default_factory=list)
     separator_cells: list[str] = field(default_factory=list)  # raw separator cells
-    raw_lines: list[str] = field(default_factory=list)        # original block lines (for fall-back)
+
+    @property
+    def rows(self) -> list[list[str]]:
+        """The genuine data rows (header + data), comment members excluded."""
+        return [cells for kind, cells in self.members if kind == 'row']
 
 
 @dataclass
@@ -198,18 +216,33 @@ def _scan_blocks(lines: list[str]) -> list[object]:
                 directive_line=directive_line,
                 is_multiline=directive_line is not None,
             )
-            tb.raw_lines.append(line)
-            tb.rows.append(split_cells(line))
+            tb.members.append(('row', split_cells(line)))
 
             sep_line = lines[i + 1]
-            tb.raw_lines.append(sep_line)
             tb.separator_cells = split_cells(sep_line)
 
             j = i + 2
-            while j < n and TABLE_ROW_RE.match(lines[j]) and not CODE_FENCE_RE.match(lines[j]):
-                tb.raw_lines.append(lines[j])
-                tb.rows.append(split_cells(lines[j]))
-                j += 1
+            while j < n and not CODE_FENCE_RE.match(lines[j]):
+                if TABLE_ROW_RE.match(lines[j]):
+                    tb.members.append(('row', split_cells(lines[j])))
+                    j += 1
+                    continue
+                if COMMENT_LINE_RE.match(lines[j]):
+                    # A full-line comment mid-table is a pass-through member,
+                    # UNLESS it is a multiline directive that opens a brand-new
+                    # adjacent table (directive + header + separator ahead), in
+                    # which case the current table closes here (issue #122).
+                    if (
+                        MULTILINE_DIRECTIVE_LINE_RE.match(lines[j])
+                        and j + 2 < n
+                        and TABLE_ROW_RE.match(lines[j + 1])
+                        and SEPARATOR_RE.match(lines[j + 2])
+                    ):
+                        break
+                    tb.members.append(('comment', lines[j]))
+                    j += 1
+                    continue
+                break
             blocks.append(tb)
             i = j
             continue
@@ -546,29 +579,38 @@ def render_standard(
     out: list[str] = []
     warnings: list[str] = []
     n_cols = len(widths)
+    header_cells = table.rows[0]
 
-    # Header row.
-    header = list(table.rows[0])
-    while len(header) < n_cols:
-        header.append('')
-    out.append(_render_row(header, widths))
+    # Walk members in order: format data rows, pass comment lines through
+    # byte-verbatim in place (issue #122). The header is the first 'row'
+    # member; the separator is derived and emitted right after it.
+    r_idx = 0
+    header_emitted = False
+    for kind, member in table.members:
+        if kind == 'comment':
+            out.append(member)
+            continue
 
-    # Separator row: derive alignments from the original separator cells.
-    alignments = [_alignment_marker(c) for c in table.separator_cells]
-    while len(alignments) < n_cols:
-        alignments.append('none')
-    sep_cells = [
-        _format_separator_cell(widths[c], alignments[c])
-        for c in range(n_cols)
-    ]
-    out.append(_render_row(sep_cells, widths))
-
-    # Data rows.
-    for r_idx, row in enumerate(table.rows[1:], start=2):
-        # Pad row to column count.
-        cells = list(row)
+        # kind == 'row'
+        r_idx += 1
+        cells = list(member)
         while len(cells) < n_cols:
             cells.append('')
+
+        if not header_emitted:
+            # Header row.
+            out.append(_render_row(cells, widths))
+            # Separator row: derive alignments from the original separator cells.
+            alignments = [_alignment_marker(c) for c in table.separator_cells]
+            while len(alignments) < n_cols:
+                alignments.append('none')
+            sep_cells = [
+                _format_separator_cell(widths[c], alignments[c])
+                for c in range(n_cols)
+            ]
+            out.append(_render_row(sep_cells, widths))
+            header_emitted = True
+            continue
 
         if _is_blank_row(cells):
             # Preserve as whitespace-only padded row (R3).
@@ -578,7 +620,7 @@ def render_standard(
         # Standard-table over-width warning (R7).
         for c, cell in enumerate(cells):
             if len(cell) > config.max_cell_width:
-                header_label = table.rows[0][c] if c < len(table.rows[0]) else f'col {c+1}'
+                header_label = header_cells[c] if c < len(header_cells) else f'col {c+1}'
                 warnings.append(
                     f"WARNING: cell exceeds max_cell_width "
                     f"({len(cell)} chars > {config.max_cell_width}) "
@@ -610,27 +652,33 @@ def render_multiline(
     if table.directive_line is not None:
         out.append(table.directive_line)
 
-    # Header row (no wrapping for the header — headers should fit by design).
-    header = list(table.rows[0])
-    while len(header) < n_cols:
-        header.append('')
-    out.append(_render_row(header, widths))
+    # Walk members in order: format data rows (wrapping long cells), pass
+    # comment lines through byte-verbatim in place (issue #122).
+    header_emitted = False
+    for kind, member in table.members:
+        if kind == 'comment':
+            out.append(member)
+            continue
 
-    # Separator row.
-    alignments = [_alignment_marker(c) for c in table.separator_cells]
-    while len(alignments) < n_cols:
-        alignments.append('none')
-    sep_cells = [
-        _format_separator_cell(widths[c], alignments[c])
-        for c in range(n_cols)
-    ]
-    out.append(_render_row(sep_cells, widths))
-
-    # Data rows.
-    for row in table.rows[1:]:
-        cells = list(row)
+        # kind == 'row'
+        cells = list(member)
         while len(cells) < n_cols:
             cells.append('')
+
+        if not header_emitted:
+            # Header row (no wrapping for the header — headers fit by design).
+            out.append(_render_row(cells, widths))
+            # Separator row.
+            alignments = [_alignment_marker(c) for c in table.separator_cells]
+            while len(alignments) < n_cols:
+                alignments.append('none')
+            sep_cells = [
+                _format_separator_cell(widths[c], alignments[c])
+                for c in range(n_cols)
+            ]
+            out.append(_render_row(sep_cells, widths))
+            header_emitted = True
+            continue
 
         if _is_blank_row(cells):
             out.append(_render_row(['' for _ in widths], widths))

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/adjacent-tables-directive-boundary/NOTES.txt
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/adjacent-tables-directive-boundary/NOTES.txt
@@ -1,0 +1,19 @@
+#122 green regression: pins the new-table lookahead exception.
+
+The first table's last data row ("Alpha") is immediately followed -- with no blank line -- by a
+<!-- multiline --> directive line, then a second table's header, separator, and one data row.
+
+Because the comment line is a multiline-directive form AND the next line is a table row AND the
+line after that is a separator row, the lookahead exception fires: the first table CLOSES at the
+directive line rather than swallowing it as a pass-through comment. The directive then becomes the
+directive line of a SECOND, adjacent multiline table.
+
+Expected output (from the real formatter):
+  - Table 1 (Term / Meaning): a standalone STANDARD table; widths planned from its own rows only.
+  - <!-- multiline --> preserved verbatim as the directive line of table 2.
+  - Table 2 (Feature / Description): a MULTILINE table; the long "Beta" cell renders on one line
+    at full width because it fits, and widths are planned from table 2's rows only.
+
+This is the complement of kl-midtable-multiline-directive, where the same directive form appears
+mid-table (NOT above a following header+separator pair) and is therefore a pass-through comment
+inside a single standard table rather than a table boundary.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/adjacent-tables-directive-boundary/expected.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/adjacent-tables-directive-boundary/expected.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-05
+status: active
+---
+
+| Term  | Meaning      |
+| ----- | ------------ |
+| Alpha | First entry. |
+<!-- multiline -->
+| Feature | Description                             |
+| ------- | --------------------------------------- |
+| Beta    | Second entry that runs a little longer. |

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/adjacent-tables-directive-boundary/input.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/adjacent-tables-directive-boundary/input.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-05
+status: active
+---
+
+| Term | Meaning |
+| ---- | ------- |
+| Alpha | First entry. |
+<!-- multiline -->
+| Feature | Description |
+| ------- | ----------- |
+| Beta | Second entry that runs a little longer. |

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/i122-condition-midtable-standard/KNOWN_FAIL.txt
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/i122-condition-midtable-standard/KNOWN_FAIL.txt
@@ -1,5 +1,0 @@
-#122
-Full-line condition tags between rows of a standard (non-multiline) table
-close the block scan today, so rows at and below the open tag pass through
-unformatted. Desired: tags preserved verbatim in place, one aligned table
-with widths planned across all rows.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/i122-condition-midtable/KNOWN_FAIL.txt
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/i122-condition-midtable/KNOWN_FAIL.txt
@@ -1,2 +1,0 @@
-#122
-A full-line condition tag inside a multiline table closes the block scan, so rows below are left unformatted and widths are planned from the top fragment only; condition tags should be in-table pass-through lines with widths planned across the whole table.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/i122-condition-midtable/NOTES.txt
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/i122-condition-midtable/NOTES.txt
@@ -1,4 +1,4 @@
-#122 red fixture: the spec's 'enterprise' condition example
+#122 fixture: the spec's 'enterprise' condition example
 (spec/multiline-cell-extensions.md, Conditions -> Wrapping Complete Rows), with ragged input
 widths.
 
@@ -6,17 +6,17 @@ The input reproduces the spec's Core / Enterprise / Community example but with i
 inconsistent pipe alignment in the source (ragged widths) to prove width planning spans the
 whole table, not just the top fragment.
 
-Today: the row-accumulation loop stops at the first line failing TABLE_ROW_RE. The
-<!--condition:enterprise--> line closes the TableBlock; the fragment below is re-scanned and
-mis-detected (observed: a spurious separator row is synthesized inside the Enterprise
-fragment, and rows below the condition are emitted unaligned). Column widths come from the
-Core fragment only.
+Before #122: the row-accumulation loop stopped at the first line failing TABLE_ROW_RE. The
+<!--condition:enterprise--> line closed the TableBlock; the fragment below was re-scanned and
+mis-detected (a spurious separator row was synthesized inside the Enterprise fragment, and
+rows below the condition were emitted unaligned). Column widths came from the Core fragment
+only.
 
-Desired (encoded in expected.md): full-line condition tags (<!--condition:enterprise--> and
-<!--/condition-->) are treated as in-table pass-through member lines -- preserved verbatim
-in place, row accumulation continuing past them -- and widths are planned across ALL rows on
-both sides of the tags, so the entire example renders as ONE aligned grid
-(Feature=10, Description=23). Blank logical-separator rows are preserved as whitespace-only
-padded rows (R3). All cell content is short enough that no wrapping occurs.
+#122 DECIDED (encoded in expected.md): full-line condition tags (<!--condition:enterprise-->
+and <!--/condition-->) are treated as in-table pass-through member lines -- preserved
+byte-verbatim in place, row accumulation continuing past them -- and widths are planned across
+ALL genuine data rows on both sides of the tags, so the entire example renders as ONE aligned
+grid (Feature=10, Description=23). Blank logical-separator rows are preserved as
+whitespace-only padded rows (R3). All cell content is short enough that no wrapping occurs.
 
 This also serves the #122 idempotency requirement (R10): the aligned output is a fixed point.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/kl-midtable-multiline-directive/KNOWN_FAIL.txt
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/kl-midtable-multiline-directive/KNOWN_FAIL.txt
@@ -1,2 +1,0 @@
-#122
-A mid-table <!-- multiline --> directive line fails TABLE_ROW_RE and closes the block, so rows below it are passed through as unformatted prose; the resolution (pass-through comment vs parse error) is pending #122.

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/kl-midtable-multiline-directive/NOTES.txt
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/tests/format-tables/kl-midtable-multiline-directive/NOTES.txt
@@ -1,23 +1,26 @@
 Known limitation ("Mid-table <!-- multiline --> directive silently splits the table"),
-whose resolution is decided in #122 (tracking ref #122, per the assignment).
+resolved by #122.
 
-Today: the row-accumulation loop stops at the first line failing TABLE_ROW_RE. The
-<!-- multiline --> line between "Alpha" and "Beta" closes the TableBlock: rows above are
-formatted, the directive line and the "Beta" row below are emitted verbatim as prose, so
-column widths are planned from the top fragment only and the Beta row is unaligned.
+Before #122: the row-accumulation loop stopped at the first line failing TABLE_ROW_RE. The
+<!-- multiline --> line between "Alpha" and "Beta" closed the TableBlock: rows above were
+formatted, the directive line and the "Beta" row below were emitted verbatim as prose, so
+column widths were planned from the top fragment only and the Beta row was left unaligned.
 
-#122 Proposal item 3 offers two acceptable resolutions for a mid-table multiline directive:
-(a) treat it as an in-table pass-through comment (preserve verbatim in place, keep
-accumulating rows), or (b) make it a parse error (exit 3). This golden encodes OPTION (a),
-the pass-through-comment option: the <!-- multiline --> line is preserved verbatim in place
-and every row above and below it is formatted as ONE aligned standard table (widths planned
-across the whole run).
+#122 DECIDED this as the pass-through-comment resolution (proposal item 3, option (a)): a
+full-line HTML comment mid-table -- including a stray <!-- multiline --> directive that is
+NOT the directive line directly above a header+separator pair -- is a pass-through member
+line, preserved byte-verbatim in place while row accumulation continues past it. The
+formatter is not a validator; mid-table the directive is just an orphaned comment and must
+not silently split the table. This golden encodes that behavior: the <!-- multiline --> line
+is preserved verbatim in place and every row above and below it is formatted as ONE aligned
+standard table (widths planned across the whole run).
 
-DESIRED BEHAVIOR PENDING #122. If #122 instead chooses the parse-error resolution, this
-case should be re-authored to expect exit code 3 (with expected-exit-code.txt = 3 and an
-expected-stderr-contains.txt), and this expected.md discarded. The implementing PR decides.
+The parse-error alternative (proposal item 3, option (b): exit 3) was NOT chosen; no
+expected-exit-code.txt / expected-stderr-contains.txt is authored here.
 
-Note: the table stays a *standard* (non-multiline) table here -- the mid-table directive is
-not on the line directly above the header, so it does not switch the table into multiline
-wrap mode; it is only a pass-through comment. The single long cell therefore renders on one
-line at its full width rather than wrapping.
+Note: the table stays a *standard* (non-multiline) table -- the mid-table directive is not on
+the line directly above the header, so it does not switch the table into multiline wrap mode;
+it is only a pass-through comment. The single long cell therefore renders on one line at its
+full width rather than wrapping. (A multiline directive that DOES sit directly above a
+following header+separator pair instead opens a new adjacent table; the lookahead exception
+is pinned by adjacent-tables-directive-boundary.)


### PR DESCRIPTION
## Summary

Implements #122: `format-tables.py`'s block scanner no longer splits a table at a full-line HTML comment.

**Behavior:** full-line comments inside a table run — condition open/close tags wrapping complete rows (the spec's Wrapping Complete Rows pattern), or any stray full-line comment including a mid-table `<!-- multiline -->` directive — become **pass-through members** of the table block: preserved byte-verbatim in place, row accumulation continuing, and column widths planned across the genuine data rows on both sides. Previously the scanner closed the block at the first non-pipe line, leaving every row below a condition tag unformatted and misaligned.

**Lookahead exception:** a multiline-directive line immediately followed by a header row and a separator row still closes the current block and opens a **new adjacent table**, preserving existing adjacent-table behavior. Pinned by the new `adjacent-tables-directive-boundary` green fixture.

**Mid-table `<!-- multiline -->` decision (issue Proposal item 3):** resolved as pass-through comment, not parse error — the formatter is not a validator, and mid-table the directive is an orphaned comment per attachment rules. The `kl-midtable-multiline-directive` NOTES now record the decision as made.

**Implementation:** `TableBlock` carries an ordered `members` list of `('row', cells)` / `('comment', raw_line)` entries with a derived `rows` property, so `plan_widths` and row padding see only genuine data rows while both renderers walk `members` in order and emit comments verbatim at their original position. CRLF handling, blank-row separators, alignment markers, warnings, and exit codes unchanged.

**Fixtures:** three `KNOWN_FAIL` cases flipped to green — `i122-condition-midtable` (the spec's `enterprise` example), `i122-condition-midtable-standard`, and `kl-midtable-multiline-directive`. All three matched their authored goldens **byte-for-byte** with zero golden reconciliation. One new green fixture pins the lookahead.

**Docs:** `references/table-formatting.md` gains rule R17 (with a note that R11–R16 are internal script requirement numbers) and a worked example generated from the real formatter; the design doc's mid-table known-limitation bullet records the resolution.

**Verification:** suite ALL GREEN — 19 pass / 16 known-fail / 0 fail / 0 unexpected-pass (`i120-linkref-condition-placement` correctly remains known-fail: its golden also requires #120's link-reference rewrite); `--idempotency` sweep 36 idempotent / 0 non-idempotent / 2 allowlisted; `sample-tables-already-formatted.md` still passes `--check` exit 0.

**Downstream:** this clears the soft prerequisite recorded on #120 — the scanner now sees condition tags as table members, so #120's link-reference definitions can be placed after `<!--/condition-->` correctly. #121 + #120 are the remaining chain.

## Terminology

- [ ] If this PR introduces or renames a Markdown++ term, `GLOSSARY.md` and at least one entry-point surface (README, spec, or skill) have been updated.

No new or renamed Markdown++ terms — formatter behavior and tooling docs only.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
