### PR TITLE
Closes #131: Fix spec 9.4 tag-above-tag phrasing; add command / comment tag / combined command glossary entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "markdown-plus-plus",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "icon": "brand/logo.svg",
   "owner": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Tooling** -- Changes to the Claude Code plugin, validation scripts, and other tools.
 - **Project** -- Repository structure, documentation, and governance changes.
 
-## [1.13.0] - 2026-07-05
+## [1.14.0] - 2026-08-11
+
+### Spec
+
+- Corrected § 9.4 "Styles and Multiline Tables": the paragraph described applying a table style "by placing it above the `<!-- multiline -->` tag via a combined command" -- self-contradictory phrasing that reads as stacked tags, which the attachment rule orphans (MDPP009). Now states that the style command and the `multiline` indicator combine **in a single combined command** attached directly above the table, with an explicit MUST NOT for stacking, matching § 14.4's existing wording. The old phrasing had already misled a RAG assistant grounded on a derived copy of this spec into answering "put the style tag above the multiline tag" ([#131](https://github.com/quadralay/markdown-plus-plus/issues/131)).
+- New `GLOSSARY.md` terms pinning the container/payload vocabulary: **command** (the instruction inside the comment), **comment tag** (the `<!-- -->` container), **combined command** (multiple commands in one tag, `;`-separated) -- each lifted from §§ 3/5/16 with the vocabulary discipline that combining is stated as "commands in the same comment tag," never as one tag placed above another. `SKILL.md`'s Combined Commands section now links the new anchors ([#131](https://github.com/quadralay/markdown-plus-plus/issues/131)).
 
 ### Tooling
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -81,3 +81,21 @@ Full treatment: [Conditions in Multiline Table Cells](spec/multiline-cell-extens
 A condition span that contains an unescaped `|` cell delimiter. A conditional cell **MUST NOT** be authored: hiding such a span removes cell boundaries and changes the row's column count, so the resulting table structure is corrupt. Because Phase 1 condition evaluation is table-blind, a processor cannot reject the pattern -- it is an authoring requirement surfaced by validation (MDPP019, warning), not processor behavior. Use conditional rows for structural differences and variables for value substitution instead.
 
 Full treatment: [Conditions in Multiline Table Cells](spec/multiline-cell-extensions.md).
+
+### command
+
+A Markdown++ instruction carried inside an HTML comment: `style:`, `#alias`, `marker:`/`markers:`, `multiline`, `condition:`/`/condition`, or `include:`. The command is the payload; the [comment tag](#comment-tag) is the `<!-- -->` container that carries it. An HTML comment whose content matches at least one recognized command pattern is an extension comment (synonym: **directive**) and is subject to Markdown++ processing; a comment matching no pattern is a regular HTML comment and is ignored. Vocabulary discipline: describe payloads as commands and reserve "tag" for the comment container -- combining is always "commands in the same comment tag, separated by `;`", never one tag placed above another (stacked tags orphan the upper tag, MDPP009).
+
+Full treatment: [Section 5 Extension Comment Syntax](spec/specification.md#5-extension-comment-syntax).
+
+### comment tag
+
+The `<!-- ... -->` HTML comment container that carries one or more Markdown++ [commands](#command). Comment syntax keeps Markdown++ extensions invisible in standard Markdown renderers -- the core backward-compatibility principle of the format. A comment tag MUST stay on a single physical line, and it binds to its target element under the [attachment rule](#attachment-rule): block-level on the line directly above the element, inline immediately before the syntax with no space between. Placement rules are stated about the comment tag; payload semantics are stated about its commands.
+
+Full treatment: [Section 5 Extension Comment Syntax](spec/specification.md#5-extension-comment-syntax).
+
+### combined command
+
+A single HTML comment containing multiple Markdown++ [commands](#command) separated by semicolons, e.g. `<!-- style:DataTable ; multiline -->` or `<!-- style:Heading2 ; #200020 -->`. Combined commands exist because the [attachment rule](#attachment-rule) makes stacked tags orphan the top tag -- one comment tag attaches to one element, so a combined command is the only way to apply several commands to the same element. Styles, the `multiline` indicator, markers, and aliases MAY combine; conditions and includes MUST NOT appear in a combined command. The recommended evaluation order is style, multiline, marker(s), alias, regardless of the order written in the comment.
+
+Full treatment: [Section 16 Combined Commands](spec/specification.md#16-combined-commands).

--- a/plugins/markdown-plus-plus/.claude-plugin/plugin.json
+++ b/plugins/markdown-plus-plus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-plus-plus",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Claude Code skill for Markdown++ authoring: syntax reference, validation, alias generation, and best practices for the open documentation format",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/markdown-plus-plus/skills/markdown-plus-plus/SKILL.md
+++ b/plugins/markdown-plus-plus/skills/markdown-plus-plus/SKILL.md
@@ -251,7 +251,7 @@ Every pipe-bearing row continues the current logical row. A row whose cells are 
 
 ### Combined Commands
 
-Multiple commands in a single comment, separated by semicolons. Order: style, multiline, marker(s), #alias.
+Multiple [commands](../../../../GLOSSARY.md#command) in a single [comment tag](../../../../GLOSSARY.md#comment-tag), separated by semicolons (see [combined command](../../../../GLOSSARY.md#combined-command)). Order: style, multiline, marker(s), #alias.
 
 ```markdown
 <!-- style:CustomHeading ; marker:Keywords="intro" ; #introduction -->

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -433,7 +433,7 @@ When styling a nested list item, the tag MUST be indented to match the nesting l
 
 **Styles and Combined Commands:** A style MAY be combined with markers, aliases, and the multiline indicator using combined command syntax. In the recommended evaluation order, the style is evaluated first. See [section 16](#16-combined-commands).
 
-**Styles and Multiline Tables:** A style MAY apply to a multiline table by placing it above the `<!-- multiline -->` tag via a combined command (`<!-- style:DataTable ; multiline -->`), or to content within table cells using inline or block placement within the cell.
+**Styles and Multiline Tables:** A style MAY apply to a multiline table as a whole by combining the style command and the `multiline` indicator in a single combined command (`<!-- style:DataTable ; multiline -->`) attached directly above the table, or to content within table cells using inline or block placement within the cell. The style and `multiline` commands MUST NOT be stacked as separate comment tags -- the upper tag would be orphaned (MDPP009).
 
 **Styles and Content Islands:** A style above a blockquote creates a content island -- a styled, self-contained content block. See [section 15](#15-content-islands).
 


### PR DESCRIPTION
Closes #131.

A RAG assistant grounded on documentation derived from this spec told a user to "put the style tag above the `multiline` tag" - stacked tags, which the attachment rule orphans (MDPP009). Both root causes live here.

## Spec

**9.4 "Styles and Multiline Tables"** rewritten: was "by placing it above the `<!-- multiline -->` tag via a combined command" (self-contradictory - a combined command has no separate multiline tag to place anything above). Now matches 14.4''s wording: the style command and the `multiline` indicator combine **in a single combined command** attached directly above the table, plus an explicit MUST NOT for stacking with the MDPP009 consequence.

## Glossary

Three new entries per the repeatable-audit procedure, definitions lifted from spec sections 3/5/16:

- **command** - the instruction inside the comment (`style:`, `#alias`, `marker:`, `multiline`, ...); notes *directive* as the spec synonym and states the vocabulary discipline: combining is "commands in the same comment tag", never tag-above-tag
- **comment tag** - the `<!-- -->` container; single-line rule and attachment behavior
- **combined command** - multiple commands in one tag, `;`-separated; why it exists (stacked tags orphan), what may/must-not combine, evaluation order

Audit pass over entry-point surfaces: `SKILL.md`''s Combined Commands section now links the three anchors (it already links the glossary for attachment rule, triple, content island, Unset); README and the references discuss these concepts only through direct spec links, so they are left untouched per the glossary''s own audit rule.

Version bumped to 1.14.0 (minor, matching the 1.11.0 precedent for spec + glossary changes); CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)